### PR TITLE
fix: There may be no PHP_EOL in the Windows

### DIFF
--- a/src/Server/Transport/Stdio/SymfonyConsoleTransport.php
+++ b/src/Server/Transport/Stdio/SymfonyConsoleTransport.php
@@ -33,14 +33,12 @@ final class SymfonyConsoleTransport implements Transport
 
     public function receive(): \Generator
     {
-        $stream = $this->input instanceof StreamableInputInterface ? $this->input->getStream() : STDIN;
-        $line = fgets($stream ?? STDIN);
-
+        $stream = $this->input instanceof StreamableInputInterface ? $this->input->getStream() ?? STDIN : STDIN;
+        $line = fgets($stream);
         if (false === $line) {
             return;
         }
-
-        $this->buffer .= $line;
+        $this->buffer .= STDIN === $stream ? rtrim($line).PHP_EOL : $line;
         if (str_contains($this->buffer, PHP_EOL)) {
             $lines = explode(PHP_EOL, $this->buffer);
             $this->buffer = array_pop($lines);


### PR DESCRIPTION
Hello, there is no problem with cmd running in windows, but I used MCP Inspector to find that the connection timed out, and after my debugging found that it did not receive PHP_EOL, it caused it to be in the receiving state forever
![image](https://github.com/user-attachments/assets/ffa3a1b7-9864-4300-a065-1b048962ad30)
