### PR TITLE
feat: remove dependency on llm-chain

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
     "require": {
         "php": "^8.2",
         "psr/log": "^3.0",
-        "symfony/uid": "^6.4 || ^7.0",
-        "php-llm/llm-chain": "^0.19.0"
+        "symfony/uid": "^6.4 || ^7.0"
     },
     "require-dev": {
         "php-cs-fixer/shim": "^3.70",

--- a/src/Capability/Tool/MetadataInterface.php
+++ b/src/Capability/Tool/MetadataInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\McpSdk\Capability\Tool;
+
+interface MetadataInterface
+{
+    public function getName(): string;
+
+    public function getDescription(): string;
+
+    public function getInputSchema(): array;
+}

--- a/src/Capability/Tool/ToolCall.php
+++ b/src/Capability/Tool/ToolCall.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\McpSdk\Capability\Tool;
+
+final readonly class ToolCall implements \JsonSerializable
+{
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    public function __construct(
+        public string $id,
+        public string $name,
+        public array $arguments = [],
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     id: string,
+     *     type: 'function',
+     *     function: array{
+     *         name: string,
+     *         arguments: string
+     *     }
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id' => $this->id,
+            'type' => 'function',
+            'function' => [
+                'name' => $this->name,
+                'arguments' => json_encode($this->arguments),
+            ],
+        ];
+    }
+}

--- a/src/Capability/Tool/ToolCollectionInterface.php
+++ b/src/Capability/Tool/ToolCollectionInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpLlm\McpSdk\Capability\Tool;
+
+interface ToolCollectionInterface
+{
+    /**
+     * @return MetadataInterface[]
+     */
+    public function getMetadata(): array;
+}

--- a/src/Capability/Tool/ToolExecutorInterface.php
+++ b/src/Capability/Tool/ToolExecutorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PhpLlm\McpSdk\Capability\Tool;
+
+use PhpLlm\McpSdk\Exception\ToolExecutionException;
+use PhpLlm\McpSdk\Exception\ToolNotFoundException;
+
+interface ToolExecutorInterface
+{
+    /**
+     * @throws ToolExecutionException if the tool execution fails
+     * @throws ToolNotFoundException  if the tool is not found
+     */
+    public function execute(ToolCall $toolCall): mixed;
+}

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\McpSdk\Exception;
+
+use PhpLlm\LlmChain\Exception\ExceptionInterface as BaseExceptionInterface;
+
+interface ExceptionInterface extends BaseExceptionInterface
+{
+}

--- a/src/Exception/ToolExecutionException.php
+++ b/src/Exception/ToolExecutionException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\McpSdk\Exception;
+
+use PhpLlm\LlmChain\Model\Response\ToolCall;
+
+final class ToolExecutionException extends \RuntimeException implements ExceptionInterface
+{
+    public ?ToolCall $toolCall = null;
+
+    public static function executionFailed(ToolCall $toolCall, \Throwable $previous): self
+    {
+        $exception = new self(sprintf('Execution of tool "%s" failed with error: %s', $toolCall->name, $previous->getMessage()), previous: $previous);
+        $exception->toolCall = $toolCall;
+
+        return $exception;
+    }
+}

--- a/src/Exception/ToolNotFoundException.php
+++ b/src/Exception/ToolNotFoundException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpLlm\McpSdk\Exception;
+
+use PhpLlm\LlmChain\Chain\Toolbox\ExecutionReference;
+use PhpLlm\LlmChain\Model\Response\ToolCall;
+
+final class ToolNotFoundException extends \RuntimeException implements ExceptionInterface
+{
+    public ?ToolCall $toolCall = null;
+
+    public static function notFoundForToolCall(ToolCall $toolCall): self
+    {
+        $exception = new self(sprintf('Tool not found for call: %s.', $toolCall->name));
+        $exception->toolCall = $toolCall;
+
+        return $exception;
+    }
+
+    public static function notFoundForReference(ExecutionReference $reference): self
+    {
+        return new self(sprintf('Tool not found for reference: %s::%s.', $reference->class, $reference->method));
+    }
+}

--- a/src/Server/RequestHandler/ToolCallHandler.php
+++ b/src/Server/RequestHandler/ToolCallHandler.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace PhpLlm\McpSdk\Server\RequestHandler;
 
-use PhpLlm\LlmChain\Chain\Toolbox\ToolboxInterface;
-use PhpLlm\LlmChain\Exception\ExceptionInterface;
-use PhpLlm\LlmChain\Model\Response\ToolCall;
+use PhpLlm\McpSdk\Capability\Tool\ToolCall;
+use PhpLlm\McpSdk\Capability\Tool\ToolExecutorInterface;
+use PhpLlm\McpSdk\Exception\ExceptionInterface;
 use PhpLlm\McpSdk\Message\Error;
 use PhpLlm\McpSdk\Message\Request;
 use PhpLlm\McpSdk\Message\Response;
@@ -14,7 +14,7 @@ use PhpLlm\McpSdk\Message\Response;
 final class ToolCallHandler extends BaseRequestHandler
 {
     public function __construct(
-        private readonly ToolboxInterface $toolbox,
+        private readonly ToolExecutorInterface $toolbox,
     ) {
     }
 
@@ -24,7 +24,7 @@ final class ToolCallHandler extends BaseRequestHandler
         $arguments = $message->params['arguments'] ?? [];
 
         try {
-            $result = $this->toolbox->execute(new ToolCall(uniqid(), $name, $arguments));
+            $result = $this->toolbox->execute(new ToolCall(uniqid('', true), $name, $arguments));
         } catch (ExceptionInterface) {
             return Error::internalError($message->id, 'Error while executing tool');
         }

--- a/src/Server/RequestHandler/ToolListHandler.php
+++ b/src/Server/RequestHandler/ToolListHandler.php
@@ -4,31 +4,33 @@ declare(strict_types=1);
 
 namespace PhpLlm\McpSdk\Server\RequestHandler;
 
-use PhpLlm\LlmChain\Chain\Toolbox\Metadata;
-use PhpLlm\LlmChain\Chain\Toolbox\ToolboxInterface;
+use PhpLlm\McpSdk\Capability\Tool\MetadataInterface;
+use PhpLlm\McpSdk\Capability\Tool\ToolCollectionInterface;
 use PhpLlm\McpSdk\Message\Request;
 use PhpLlm\McpSdk\Message\Response;
 
 final class ToolListHandler extends BaseRequestHandler
 {
     public function __construct(
-        private readonly ToolboxInterface $toolbox,
+        private readonly ToolCollectionInterface $toolbox,
     ) {
     }
 
     public function createResponse(Request $message): Response
     {
         return new Response($message->id, [
-            'tools' => array_map(function (Metadata $tool) {
+            'tools' => array_map(function (MetadataInterface $tool) {
+                $inputSchema = $tool->getInputSchema();
+
                 return [
-                    'name' => $tool->name,
-                    'description' => $tool->description,
-                    'inputSchema' => $tool->parameters ?? [
+                    'name' => $tool->getName(),
+                    'description' => $tool->getDescription(),
+                    'inputSchema' => [] === $inputSchema ? [
                         'type' => 'object',
                         '$schema' => 'http://json-schema.org/draft-07/schema#',
-                    ],
+                    ] : $inputSchema,
                 ];
-            }, $this->toolbox->getMap()),
+            }, $this->toolbox->getMetadata()),
         ]);
     }
 


### PR DESCRIPTION
We would like this package to be the low-level package. Ie, we cannot have a dependency to the high-level `php-llm/llm-chain`. 

I have moved models and interfaces to this package. These will of course be part of the contract. I'll continue this work with adding support other capabilities like for Resources and Prompts