### PR TITLE
fix: make sure we can convert Request and Notification to string

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -38,6 +38,10 @@ jobs:
 
   qa:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -38,10 +38,6 @@ jobs:
 
   qa:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/src/Message/Notification.php
+++ b/src/Message/Notification.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpLlm\McpSdk\Message;
 
-final readonly class Notification implements \JsonSerializable
+final readonly class Notification implements \JsonSerializable, \Stringable
 {
     /**
      * @param array<string, mixed>|null $params

--- a/src/Message/Notification.php
+++ b/src/Message/Notification.php
@@ -37,4 +37,9 @@ final readonly class Notification implements \JsonSerializable
             'params' => $this->params,
         ];
     }
+
+    public function __toString(): string
+    {
+        return sprintf('%s', $this->method);
+    }
 }

--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpLlm\McpSdk\Message;
 
-final class Request implements \JsonSerializable
+final class Request implements \JsonSerializable, \Stringable
 {
     /**
      * @param array<string, mixed>|null $params

--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -40,4 +40,9 @@ final class Request implements \JsonSerializable
             'params' => $this->params,
         ];
     }
+
+    public function __toString(): string
+    {
+        return sprintf('%s: %s', $this->id, $this->method);
+    }
 }


### PR DESCRIPTION
This is already used when we are logging.

https://github.com/php-llm/mcp-sdk/blob/5e795d98d2fb98fb84f4c8bd73de9a1020ebe477/src/Server/JsonRpcHandler.php#L56