### PR TITLE
ci: add permissions to modify labels

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -39,6 +39,7 @@ jobs:
   qa:
     runs-on: ubuntu-latest
     permissions:
+      issues: write
       pull-requests: write
 
     steps:


### PR DESCRIPTION
This is a poor attempt to fix the CI. I think the issue is that we are trying to create labels that do not exist. The readme says: 

> If you encounter an error message: Error: Resource not accessible by integration, adjust your repository settings. Go to your repository's settings, navigate to the "Actions" tab, and under the "General" section, update the "Workflow permissions" setting to "Read and Write Permission". This grants the necessary permissions for the action to function correctly.

But that feels too generous. 